### PR TITLE
1.0.0-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.0-rc] - 2022-02-26
+
+### [1.0.0-rc] Added
+
+- `Number` object. [32c36d4]
+- `value` parameter of number type to the static `create()` method and `constructor()`. [622847e]
+- private `#value` property that indicates the range current value of the number type. [622847e]
+- `get` accessor `value` to retrieve the range value. [622847e]
+- `set` accessor `value` to set the `#range` property including range of specified object. [622847e]
+- `get` accessor `steps` to retrieve the number of steps. [622847e]
+- the `getCurrentRange()` `getCurrentStep()` `getValueOfStep()` `setValue()` `setValueToStep()` `valueDown()` `valueUp()` methods. [622847e]
+
+### [1.0.0-rc] Changed
+
+- the static `isRange()` method by adding `step` parameter to check. [870c5e4]
+- deprecate `getMin()` `getMax()` `valueOf()` `toArray()` methods. [622847e]
+- `get` accessor `range`  to use `getRange()` method of instance and its return type to readonly. [622847e]
+- the `getRange()` method to obtains the range to the specified value. [622847e]
+- the `isBetween()` `isBetweenEvery()` `isBetweenSome()` methods to include minimum and maximum. [622847e]
+- `forEachStep()` method parameter names and set `range` parameter type to readonly. [622847e]
+
+[870c5e4]: https://github.com/angular-package/range/commit/870c5e4abb6addf140d6ae85ad7018b8ea117280
+[32c36d4]: https://github.com/angular-package/range/commit/32c36d4ea5f3b7745571cb4034cd8e887aac2a00
+[622847e]: https://github.com/angular-package/range/commit/622847e0d3042da88137e8a36c69fdeb3a8b7054
+
 ## [1.0.0-beta.0] - 2022-02-22
 
 ### [1.0.0-beta.0] Added

--- a/src/lib/number.class.ts
+++ b/src/lib/number.class.ts
@@ -5,20 +5,10 @@ import { Inequality } from './inequality.class';
  * less than the given.
  */
 export class Number<Value extends number> extends Inequality<Value> {
-  //#region instance public properties.
-  /**
-   * The `get` accessor, with the help of `toStringTag`, changes the default tag to `'Number'` for an instance of `Number`. It can be read
-   * by the `typeOf()` function of `@angular-package/type`.
-   */
-  public get [Symbol.toStringTag](): string {
-    return 'Number';
-  }
-  //#endregion instance public properties.
-
   //#region static public methods.
   /**
    * Creates the `Number` instance with the given primitive `value`.
-   * @param value The maximum number of generic type variable `Value` to set with a new instance.
+   * @param value The number of generic type variable `Value` to set with a new instance.
    * @returns The return value is the `Number` instance of the given primitive `value`.
    * @angularpackage
    */
@@ -29,18 +19,19 @@ export class Number<Value extends number> extends Inequality<Value> {
   /**
    * Checks whether the value of any type is the `Number` instance of any or the given primitive value.
    * @param value The value of any type to test against the `Number` instance.
-   * @param max Optional maximum of the generic type variable `Value` to check if it's the primitive value of the given `value`.
-   * @returns The return value is a `boolean` indicating whether the provided value is an instance of `Number`.
+   * @param numberValue Optional number of the generic type variable `Value` to check if it's the primitive value of the given `value`.
+   * @returns The return value is a `boolean` indicating whether the provided value is an instance of `Number` of any or the given
+   * `numberValue`.
    * @angularpackage
    */
   public static isNumber<Value extends number>(
     value: any,
-    max?: Value
+    numberValue?: Value
   ): value is Number<Value> {
     return (
       typeof value === 'object' &&
       value instanceof this &&
-      (typeof max === 'number' ? value.valueOf() === max : true)
+      (typeof numberValue === 'number' ? value.valueOf() === numberValue : true)
     );
   }
   //#endregion static methods.

--- a/src/lib/range.class.ts
+++ b/src/lib/range.class.ts
@@ -11,7 +11,7 @@ export class Range<
 > {
   //#region instance accessors.
   /**
-   * The `get` accessor obtains the range of an `Array` number from the minimum to the maximum with the step of a specified `Range` object.
+   * The `get` accessor obtains the range of an `Array` of the minimum to the maximum with the step of a specified `Range` object.
    * @returns The return value is the range from minimum to maximum of an `Array` of number.
    * @angularpackage
    */
@@ -84,11 +84,11 @@ export class Range<
 
   //#region static public methods.
   /**
-   * The static `create()` method returns a new instance of `Range` with a range of the given `min` and `max`.
+   * The static `create()` method returns a new instance of `Range` with a range of the given required `min`, `max` and optional `step`.
    * @param min The **minimum** range of generic type variable `Min` to set with a new `Range` instance.
    * @param max The **maximum** range of generic type variable `Max` to set with a new `Range` instance.
-   * @param step Optional step to set with a new `Range` instance, by default 1.
-   * @returns The return value is the `Range` instance with a range of the given `min` and `max`.
+   * @param step Optional step of generic type variable `Step` to set with a new `Range` instance, by default `1`.
+   * @returns The return value is the `Range` instance with a range of the given required `min`, `max` and optional `step`.
    * @angularpackage
    */
   public static create<
@@ -102,8 +102,8 @@ export class Range<
   /**
    * Creates the `Range` instance from the given random numbers and the step.
    * @param numbers An `Array` of numbers to find a range and create a new instance.
-   * @param step Optional step to set with a new `Range` instance, by default 1.
-   * @returns The return value is the `Range` instance created from the given numbers and a step.
+   * @param step Optional step of generic type variable `Step` to set with a new `Range` instance, by default `1`.
+   * @returns The return value is the `Range` instance created from the given required random numbers and the optional step.
    * @angularpackage
    */
   public static createFrom<Step extends number = 1>(
@@ -142,31 +142,40 @@ export class Range<
   }
 
   /**
-   * The static `isRange()` method checks whether the `value` is an instance of `Range` of any or the given minimum and maximum range.
+   * The static `isRange()` method checks whether the `value` is an instance of `Range` of any or the given minimum, maximum range, and
+   * step.
    * @param value The value of any type to test against the `Range` instance.
    * @param min The optional minimum range of generic type variable `Min` to check whether it's equal to a minimum of the given `value`.
    * @param max The optional maximum range of generic type variable `Max` to check whether it's equal to a maximum of the given `value`.
-   * @returns The return value is a boolean indicating whether the provided `value` is an instance of `Range` of any or the given minimum
-   * and maximum range.
+   * @param step Optional step of generic type variable `Step` to check whether it's equal to the step of the given `value`.
+   * @returns The return value is a boolean indicating whether the provided `value` is an instance of `Range` of any or the given minimum,
+   * maximum range and step.
    * @angularpackage
    */
-  public static isRange<Min extends number, Max extends number>(
+  public static isRange<
+    Min extends number,
+    Max extends number,
+    Step extends number
+  >(
     value: any,
     min?: Min,
-    max?: Max
-  ): value is Range<Min, Max> {
+    max?: Max,
+    step?: Step
+  ): value is Range<Min, Max, Step> {
     return typeof value === 'object' && value instanceof this
       ? (typeof min === 'number' ? value.min === min : true) &&
-          (typeof max === 'number' ? value.max === max : true)
+          (typeof max === 'number' ? value.max === max : true) &&
+          (typeof step === 'number' ? value.step === step : true)
       : false;
   }
   //#endregion static public methods.
 
   //#region constructor.
   /**
-   * Creates the `Range` instance with a range of the given `min` and `max`.
+   * Creates the `Range` instance with a range of the given required `min`, `max` and optional `step`.
    * @param min The minimum range of generic type variable `Min` to set with a new `Range` instance.
    * @param max The maximum range of generic type variable `Max` to set with a new `Range` instance.
+   * @param step Optional step of generic type variable `Step` to set with a new `Range` instance, by default `1`.
    * @returns The return value is a new instance of `Range` of the given minimum and maximum.
    * @angularpackage
    */
@@ -192,39 +201,43 @@ export class Range<
 
   //#region instance public methods.
   /**
-   * The `stepByStep()` method performs a callback function with the ability to decide when to move to the next step of the range.
-   * @param callbackFn A function that accepts up to three arguments. The `value` is a function generator that allows deciding when to move
-   * to the next step, `step` is the step, and `max` is the maximum of a specified `Range` object.
-   * @returns The return value is the `Range` instance.
-   * @angularpackage
-   */
-  public stepByStep(
-    callbackFn: (value: Generator<number>, step: Step, max: Max) => void
-  ): this {
-    const t = this;
-    callbackFn(
-      (function* stepByStep(current = t.min - t.step): Generator<number> {
-        while (current < t.max) {
-          yield (current += t.step);
-        }
-      })(),
-      t.step,
-      t.max
-    );
-    return this;
-  }
-
-  /**
    * The `forEachStep()` method performs the specified action for each step in the range of an array.
    * @param forEachStep A function that accepts up to three arguments. It's called one time for each step in the range.
    * @returns The return value is the `Range` instance.
    * @angularpackage
    */
   public forEachStep(
-    forEachStep: (value: number, index: number, range: number[]) => void
+    forEachStep: (step: number, index: number, range: number[]) => void
   ): this {
     this.range.forEach(forEachStep);
     return this;
+  }
+
+  /**
+   * The `getMax()` method gets the maximum range of a specified `Range` object.
+   * @returns The return value is the maximum range of a generic type variable `Max`.
+   * @angularpackage
+   */
+  public getMax(): Max {
+    return this.#maximum.valueOf();
+  }
+
+  /**
+   * The `getMin()` method gets the minimum range of a specified `Range` object.
+   * @returns The return value is the minimum range of a generic type variable `Min`.
+   * @angularpackage
+   */
+  public getMin(): Min {
+    return this.#minimum.valueOf();
+  }
+
+  /**
+   * The `getRange()` method returns a range of numbers from minimum to maximum with the step of a specified `Range` object.
+   * @returns The return value is a range of numbers from minimum to maximum of a read-only `Array`.
+   * @angularpackage
+   */
+  public getRange(): Readonly<Array<number>> {
+    return this.range;
   }
 
   /**
@@ -301,33 +314,6 @@ export class Range<
   }
 
   /**
-   * The `getMax()` method gets the maximum range of a specified `Range` object.
-   * @returns The return value is the maximum range of a generic type variable `Max`.
-   * @angularpackage
-   */
-  public getMax(): Max {
-    return this.#maximum.valueOf();
-  }
-
-  /**
-   * The `getMin()` method gets the minimum range of a specified `Range` object.
-   * @returns The return value is the minimum range of a generic type variable `Min`.
-   * @angularpackage
-   */
-  public getMin(): Min {
-    return this.#minimum.valueOf();
-  }
-
-  /**
-   * The `getRange()` method returns a range of numbers from minimum to maximum with the step of a specified `Range` object.
-   * @returns The return value is a range of numbers from minimum to maximum of a read-only `Array`.
-   * @angularpackage
-   */
-  public getRange(): Readonly<Array<number>> {
-    return this.range;
-  }
-
-  /**
    * The `maxGreaterThan()` method checks whether the value is less than the maximum range of a specified `Range` object.
    * @param value The value of number type to test.
    * @returns The return value is a `boolean` type indicating whether the given `value` is less than maximum range of a specified `Range`
@@ -369,6 +355,29 @@ export class Range<
    */
   public minLessThan(value: number): boolean {
     return this.#minimum.lessThan(value);
+  }
+
+  /**
+   * The `stepByStep()` method performs a callback function with the ability to decide when to move to the next step of the range.
+   * @param callbackFn A function that accepts up to three arguments. The `value` is a function generator that allows deciding when to move
+   * to the next step, `step` is the step, and `max` is the maximum of a specified `Range` object.
+   * @returns The return value is the `Range` instance.
+   * @angularpackage
+   */
+  public stepByStep(
+    callbackFn: (value: Generator<number>, step: Step, max: Max) => void
+  ): this {
+    const t = this;
+    callbackFn(
+      (function* stepByStep(current = t.min - t.step): Generator<number> {
+        while (current < t.max) {
+          yield (current += t.step);
+        }
+      })(),
+      t.step,
+      t.max
+    );
+    return this;
   }
 
   /**

--- a/src/lib/range.class.ts
+++ b/src/lib/range.class.ts
@@ -12,26 +12,51 @@ export class Range<
   //#region instance accessors.
   /**
    * The `get` accessor obtains the range of an `Array` of the minimum to the maximum with the step of a specified `Range` object.
-   * @returns The return value is the range from minimum to maximum of an `Array` of number.
+   * @returns The return value is the range from minimum to the maximum of a read-only `Array` of number.
    * @angularpackage
    */
-  public get range(): Array<number> {
-    const arr = [];
-    let range: number = this.min - this.step;
-    while (range < this.max) {
-      range += this.step;
-      range <= this.max && arr.push(range);
-    }
-    return arr;
+  public get range(): Readonly<Array<number>> {
+    return this.getRange();
   }
 
   /**
-   * The `get` accessor obtains the step of a specified `Range` object.
+   * The `get` accessor obtains the step of a specified `Range` object. It's used to return the entire range or current range.
    * @returns The return value is the step of generic type variable `Step`.
    * @angularpackage
    */
   public get step(): Step {
     return this.#step;
+  }
+
+  /**
+   * The `get` accessor retrieves the number of steps of the specified `Range` object.
+   * @returns The return value is the number of steps of the `number` type.
+   * @angularpackage
+   */
+  public get steps(): number {
+    return this.getRange().length;
+  }
+
+  /**
+   * The `get` accessor retrieves the `#value` property that indicates the range current value of the `number` type of a specified `Range`
+   * object. It can be set by the `setValue()` method.
+   * @returns The return value is the range current value of `number` type if set, otherwise `undefined`.
+   * @angularpackage
+   */
+  public get value(): number | undefined {
+    return this.#value;
+  }
+
+  /**
+   * The `set` accessor sets the range current value of the `number` type between the minimum and maximum of a specified `Range`
+   * object.
+   * @returns The return value is the range current value of `number` type if set, otherwise `undefined`.
+   * @angularpackage
+   */
+  public set value(value: number | undefined) {
+    typeof value === 'number'
+      ? this.has(value) && (this.#value = value)
+      : undefined;
   }
 
   /**
@@ -49,15 +74,11 @@ export class Range<
   //#region public instance properties.
   /**
    * The `max` read-only property is the maximum range of generic type variable `Max` of a specified `Range` object.
-   * @returns The return value is the maximum range of generic type variable `Max`.
-   * @angularpackage
    */
   public readonly max!: Max;
 
   /**
    * The `min` read-only property is the minimum range of generic type variable `Min` of a specified `Range` object.
-   * @returns The return value is the minimum range of generic type variable `Min`.
-   * @angularpackage
    */
   public readonly min!: Min;
   //#endregion public instance properties.
@@ -76,27 +97,35 @@ export class Range<
   #minimum: Minimum<Min>;
 
   /**
-   * Private property of the generic type variable `Step` indicates the range step.
+   * The private property of the generic type variable `Step` indicates the range step.
    */
   #step: Step;
+
+  /**
+   * The private property of the `number` type indicates the range value.
+   */
+  #value?: number;
   //#endregion private instance properties.
   //#endregion instance properties.
 
   //#region static public methods.
   /**
-   * The static `create()` method returns a new instance of `Range` with a range of the given required `min`, `max` and optional `step`.
+   * The static `create()` method returns a new instance of `Range` with a range of the given required `min`, `max` and optional current
+   * `value`, `step`.
    * @param min The **minimum** range of generic type variable `Min` to set with a new `Range` instance.
    * @param max The **maximum** range of generic type variable `Max` to set with a new `Range` instance.
+   * @param value The optional value of the `number` type between the given `min` and `max` specifies the default value of a new `Range`
+   * instance.
    * @param step Optional step of generic type variable `Step` to set with a new `Range` instance, by default `1`.
-   * @returns The return value is the `Range` instance with a range of the given required `min`, `max` and optional `step`.
+   * @returns The return value is the `Range` instance with a range of the given required `min`, `max` and optional current `value`, `step`.
    * @angularpackage
    */
   public static create<
     Min extends number,
     Max extends number,
     Step extends number = 1
-  >(min: Min, max: Max, step?: Step): Range<Min, Max, Step> {
-    return new this(min, max, step);
+  >(min: Min, max: Max, value?: number, step?: Step): Range<Min, Max, Step> {
+    return new this(min, max, value, step);
   }
 
   /**
@@ -172,17 +201,21 @@ export class Range<
 
   //#region constructor.
   /**
-   * Creates the `Range` instance with a range of the given required `min`, `max` and optional `step`.
+   * Creates the `Range` instance with a range of the given required `min`, `max` and optional current `value`, `step`.
    * @param min The minimum range of generic type variable `Min` to set with a new `Range` instance.
    * @param max The maximum range of generic type variable `Max` to set with a new `Range` instance.
+   * @param value The optional value of the `number` type between the given `min` and `max` specifies the default value of a new `Range`
+   * instance.
    * @param step Optional step of generic type variable `Step` to set with a new `Range` instance, by default `1`.
    * @returns The return value is a new instance of `Range` of the given minimum and maximum.
    * @angularpackage
    */
-  constructor(min: Min, max: Max, step: Step = 1 as Step) {
+  constructor(min: Min, max: Max, value?: number, step: Step = 1 as Step) {
     this.#maximum = new Maximum(max);
     this.#minimum = new Minimum(min);
     this.#step = step;
+    // Sets the range value between the given `min` and `max`.
+    this.value = value;
     // Define the `min` and `max` property.
     Object.defineProperties(this, {
       min: {
@@ -201,19 +234,43 @@ export class Range<
 
   //#region instance public methods.
   /**
-   * The `forEachStep()` method performs the specified action for each step in the range of an array.
-   * @param forEachStep A function that accepts up to three arguments. It's called one time for each step in the range.
+   * The `forEachStep()` method performs the specified action for each step in the maximum range of an `Array`.
+   * @param forEachStep A `function` that accepts up to three arguments. It's called one time for each step in the range.
    * @returns The return value is the `Range` instance.
    * @angularpackage
    */
   public forEachStep(
-    forEachStep: (step: number, index: number, range: number[]) => void
+    forEachStep: (value: number, step: number, range: readonly number[]) => void
   ): this {
     this.range.forEach(forEachStep);
     return this;
   }
 
   /**
+   * The `getCurrentRange()` method returns a range of numbers from minimum to the current value by the step of a specified `Range` object.
+   * @returns The return value is a range of numbers of a read-only `Array` from minimum to the current value, if the current value is set,
+   * otherwise `undefined`.
+   * @angularpackage
+   */
+  public getCurrentRange(): Readonly<Array<number>> | undefined {
+    return typeof this.value === 'number'
+      ? this.getRange(this.value)
+      : undefined;
+  }
+
+  /**
+   * The `getCurrentStep()` method returns the step of the range value.
+   * @returns The return value is the step of `number` type, if range value is set, otherwise `undefined`.
+   * @angularpackage
+   */
+  public getCurrentStep(): number | undefined {
+    return typeof this.value === 'number'
+      ? Math.floor(this.value / this.step)
+      : undefined;
+  }
+
+  /**
+   * @deprecated
    * The `getMax()` method gets the maximum range of a specified `Range` object.
    * @returns The return value is the maximum range of a generic type variable `Max`.
    * @angularpackage
@@ -223,6 +280,7 @@ export class Range<
   }
 
   /**
+   * @deprecated
    * The `getMin()` method gets the minimum range of a specified `Range` object.
    * @returns The return value is the minimum range of a generic type variable `Min`.
    * @angularpackage
@@ -232,12 +290,47 @@ export class Range<
   }
 
   /**
-   * The `getRange()` method returns a range of numbers from minimum to maximum with the step of a specified `Range` object.
-   * @returns The return value is a range of numbers from minimum to maximum of a read-only `Array`.
+   * The `getRange ()` method returns a range of numbers by the specified step from minimum to the given `value` of the specified` Range`
+   * object.
+   * @param value Optional maximum range value of `number` type of returned `array` by default the `value` is the maximum range.
+   * @returns The return value is a range of numbers of a read-only `Array` from minimum to the given `value`.
    * @angularpackage
    */
-  public getRange(): Readonly<Array<number>> {
-    return this.range;
+  public getRange(value: number = this.max): Readonly<Array<number>> {
+    const range = [];
+    let current: number = this.min;
+    while (current <= value) {
+      current <= this.max && range.push(current), (current += this.#step);
+    }
+    return range;
+  }
+
+  /**
+   * The `getRangeOfStep()` method returns a range of numbers by the specified step from the minimum to the given `step` of a specified
+   * `Range` object.
+   * @param step Step of `number` type is the maximum range of the returned `array`. The value must be less or equal to the number of range
+   * steps.
+   * @returns The return value is a range of numbers of a read-only `Array` from minimum to step of the given `toStep`.
+   * @angularpackage
+   */
+  public getRangeOfStep(step: number): Readonly<Array<number>> {
+    const range = [];
+    if (step > 0 && step <= this.steps) {
+      for (let value = 0; value < step; value++) {
+        range.push(this.min + value * this.#step);
+      }
+    }
+    return range;
+  }
+
+  /**
+   * The `getValueOfStep()` method returns the range value of the given `step`.
+   * @param step Step parameter of `number` type to retrieve the range value.
+   * @returns The return value is the range value of the given `step` if exists otherwise `undefined`.
+   * @angularpackage
+   */
+  public getValueOfStep(step: number): number | undefined {
+    return step > 0 && step <= this.steps ? this.range[step - 1] : undefined;
   }
 
   /**
@@ -284,38 +377,38 @@ export class Range<
    * @angularpackage
    */
   public isBetween(min: number, max: number): boolean {
-    return min < max ? this.hasEvery(min, max) : false;
+    return min <= max ? this.hasEvery(min, max) : false;
   }
 
   /**
    * Checks whether the range of a specified `Range` object is between every range of the given `ranges`.
-   * @param ranges A rest parameter of array type ranges to test.
+   * @param ranges A rest parameter of ranges of an `array` type to test.
    * @returns The return value is a `boolean` type indicating whether the range of a specified `Range` object is between every range of the
    * given `ranges`.
    * @angularpackage
    */
   public isBetweenEvery(...ranges: [number, number][]): boolean {
     return ranges.every((range) =>
-      range[0] < range[1] ? this.hasEvery(...range) : false
+      range[0] <= range[1] ? this.hasEvery(...range) : false
     );
   }
 
   /**
    * Checks whether the range of a specified `Range` object is between some given `ranges`.
-   * @param ranges A rest parameter of array type ranges to test.
+   * @param ranges A rest parameter of an `array` type ranges to test.
    * @returns The return value is a `boolean` type indicating whether the range of a specified `Range` object is between some given
    * `ranges`.
    * @angularpackage
    */
   public isBetweenSome(...ranges: [number, number][]): boolean {
     return ranges.some((range) =>
-      range[0] < range[1] ? this.hasEvery(...range) : false
+      range[0] <= range[1] ? this.hasEvery(...range) : false
     );
   }
 
   /**
    * The `maxGreaterThan()` method checks whether the value is less than the maximum range of a specified `Range` object.
-   * @param value The value of number type to test.
+   * @param value The value of `number` type to test.
    * @returns The return value is a `boolean` type indicating whether the given `value` is less than maximum range of a specified `Range`
    * object.
    * @angularpackage
@@ -326,7 +419,7 @@ export class Range<
 
   /**
    * The `maxLessThan()` method checks whether the value is greater than the maximum range of a specified `Range` object.
-   * @param value The value of number type to test.
+   * @param value The value of `number` type to test.
    * @returns The return value is a `boolean` type indicating whether the given `value` is greater than maximum range of a specified `Range`
    * object.
    * @angularpackage
@@ -337,7 +430,7 @@ export class Range<
 
   /**
    * The `minGreaterThan()` method checks whether the value is less than a minimum range of a specified `Range` object.
-   * @param value The value of number type to test.
+   * @param value The value of `number` type to test.
    * @returns The return value is a `boolean` type indicating whether the given `value` is less than minimum range of a specified `Range`
    * object.
    * @angularpackage
@@ -348,13 +441,41 @@ export class Range<
 
   /**
    * The method `minLessThan()` checks whether the value is greater than the minimum range of a specified `Range` object.
-   * @param value The value of number type to test.
+   * @param value The value of `number` type to test.
    * @returns The return value is a `boolean` type indicating whether the given `value` is greater than minimum range of a specified `Range`
    * object.
    * @angularpackage
    */
   public minLessThan(value: number): boolean {
     return this.#minimum.lessThan(value);
+  }
+
+  /**
+   * The method `setValue()` sets the range value between the minimum and maximum of a specified `Range` object. If the given `value` is not
+   * within range, it's not set.
+   * @param value The value of `number` type to set.
+   * @returns The return value is the `Range` instance.
+   * @angularpackage
+   */
+  public setValue(value: number): this {
+    this.value = value;
+    return this;
+  }
+
+  /**
+   * The method `setValueToStep()` sets the value of the specified `Range` object to the value of the given `step`.
+   * @param step Step of `number` type to retrieve the value from the range and set it as the range current value.
+   * @returns The return value is the `Range` instance.
+   * @angularpackage
+   */
+  public setValueToStep(step: number): this {
+    step > 0 &&
+      Object.defineProperty(this, 'value', {
+        configurable: true,
+        value: this.getValueOfStep(step),
+        writable: false,
+      });
+    return this;
   }
 
   /**
@@ -381,6 +502,7 @@ export class Range<
   }
 
   /**
+   * @deprecated
    * The `toArray()` method returns a read-only array of the range in order minimum and maximum.
    * @returns The return value is a read-only array of the range in order minimum and maximum.
    * @angularpackage
@@ -390,6 +512,21 @@ export class Range<
   }
 
   /**
+   * The `valueDown()` method decrements the range value of a specified `Range` object by the range step or given `stepDecrement`.
+   * @param stepIncrement The optional `stepDecrement` parameter of the `number` type decrements the range value. If no parameter is passed,
+   * `stepDecrement` defaults to `1`.
+   * @returns The return value is the `Range` instance.
+   * @angularpackage
+   */
+  public valueDown(stepDecrement = 1): this {
+    typeof this.value === 'number' &&
+      stepDecrement > 0 &&
+      this.setValue(this.value - stepDecrement * this.#step);
+    return this;
+  }
+
+  /**
+   * @deprecated
    * The `valueOf()` method returns a read-only object consisting of the primitive values of `Minimum` and `Maximum` instances.
    * @returns The return value is a frozen `object` consisting of the primitive values of `Minimum` and `Maximum` instances.
    * @angularpackage
@@ -399,6 +536,20 @@ export class Range<
       min: this.#minimum.valueOf(),
       max: this.#maximum.valueOf(),
     });
+  }
+
+  /**
+   * The `valueUp()` method increments the range value of a specified `Range` object by the range step or given `stepIncrement`.
+   * @param stepIncrement The optional `stepIncrement` parameter of the `number` type increments the range value. If no parameter is passed,
+   * `stepIncrement` defaults to `1`.
+   * @returns The return value is the `Range` instance.
+   * @angularpackage
+   */
+  public valueUp(stepIncrement = 1): this {
+    typeof this.value === 'number' &&
+      stepIncrement > 0 &&
+      this.setValue(this.value + stepIncrement * this.#step);
+    return this;
   }
   //#endregion instance public methods.
 }

--- a/src/test/greater.spec.ts
+++ b/src/test/greater.spec.ts
@@ -1,0 +1,43 @@
+// @angular-package/testing.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+// Class to test.
+import { Greater } from '../lib/greater.class';
+
+// Initialize.
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+
+testing.describe(`Greater.`, () => {
+
+  // Properties.
+  const min = -27;
+  const max = 27;
+  const step = 3;
+  const value = 25;
+
+  // Create new instance.
+  // Returns Range {min: 3, max: 27, value: 10} of Range<3, 27, 3>.
+  let greater = new Greater(value);
+
+  beforeEach(() => greater = new Greater(value));
+
+  testing.it(`create()`, () => {
+    expect(Greater.create(min)).toBeInstanceOf(Greater);
+    toBe.instance(Greater.create(min), Greater);
+  })
+  .describe(`prototype.`, () => {
+    testing
+    .it(`than()`, () => {
+      expect(greater.than(max)).toBeFalse();
+      expect(greater.than(min)).toBeTrue();
+    })
+    .it(`thanEvery()`, () => {
+      expect(greater.thanEvery(23, 24, 25)).toBeFalse();
+      expect(greater.thanEvery(23, 24)).toBeTrue();
+    })
+    .it(`thanSome()`, () => {
+      expect(greater.thanSome(23, 24, 25)).toBeTrue();
+      expect(greater.thanSome(25, 26, 27)).toBeFalse();
+    });
+  });
+});

--- a/src/test/inequality.spec.ts
+++ b/src/test/inequality.spec.ts
@@ -1,0 +1,49 @@
+// @angular-package/testing.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+// Class to test.
+import { Inequality } from '../lib/inequality.class';
+
+// Initialize.
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+
+testing.describe(`Inequality.`, () => {
+
+  // Define the `Age` class and extend it with `Inequality`.
+  class Age<Value extends number> extends Inequality<Value> {}
+
+  // Define the `Year` class and extend it with `Inequality`.
+  class Year<Value extends number> extends Inequality<Value> {}
+
+  const min = 0;
+  const max = 100;
+
+  // Initialize `Age`.
+  let age = new Age(27);
+
+  beforeEach(() => (age = new Age(27)));
+
+  testing
+    .describe(`prototype.`, () =>
+      testing
+      .it(`isBetween()`, () => {
+        expect(age.isBetween(min, max)).toBeTrue();
+        expect(age.isBetween(min, 26)).toBeFalse();
+        expect(age.isBetween(28, max)).toBeFalse();
+      })
+      .it(`isBetweenEvery()`, () => {
+        expect(age.isBetweenEvery([min, max], [min, 27], [27, max])).toBeTrue();
+        expect(age.isBetweenEvery([min, max], [min, 26], [28, max])).toBeFalse();
+      })
+      .it(`isBetweenSome()`, () => {
+        expect(age.isBetweenSome([min, max], [min, 27], [27, max])).toBeTrue();
+        expect(age.isBetweenSome([min, max], [min, 26], [28, max])).toBeTrue();
+        expect(age.isBetweenSome([min, 26], [28, max])).toBeFalse();
+      })
+      .it(`isBetweenSome()`, () => {
+        expect(age.isBetweenSome([min, max], [min, 27], [27, max])).toBeTrue();
+        expect(age.isBetweenSome([min, max], [min, 26], [28, max])).toBeTrue();
+        expect(age.isBetweenSome([min, 26], [28, max])).toBeFalse();
+      })
+    );
+});

--- a/src/test/less.spec.ts
+++ b/src/test/less.spec.ts
@@ -1,0 +1,43 @@
+// @angular-package/testing.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+// Class to test.
+import { Less } from '../lib/less.class';
+
+// Initialize.
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+
+testing.describe(`Less.`, () => {
+
+  // Properties.
+  const min = -27;
+  const max = 27;
+  const step = 3;
+  const value = 25;
+
+  // Create new instance.
+  // Returns Range {min: 3, max: 27, value: 10} of Range<3, 27, 3>.
+  let less = new Less(value);
+
+  beforeEach(() => less = new Less(value));
+
+  testing.it(`create()`, () => {
+    expect(Less.create(min)).toBeInstanceOf(Less);
+    toBe.instance(Less.create(min), Less);
+  })
+  .describe(`prototype.`, () => {
+    testing
+    .it(`than()`, () => {
+      expect(less.than(max)).toBeTrue();
+      expect(less.than(min)).toBeFalse();
+    })
+    .it(`thanEvery()`, () => {
+      expect(less.thanEvery(25, 26, 27)).toBeFalse();
+      expect(less.thanEvery(26, 27)).toBeTrue();
+    })
+    .it(`thanSome()`, () => {
+      expect(less.thanSome(23, 24, 25)).toBeFalse();
+      expect(less.thanSome(25, 26, 27)).toBeTrue();
+    });
+  });
+});

--- a/src/test/maximum.spec.ts
+++ b/src/test/maximum.spec.ts
@@ -1,0 +1,33 @@
+// @angular-package/testing.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+// Class.
+import { Maximum } from '../lib/maximum.class';
+
+// Initialize.
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+
+testing.describe(`Maximum.`, () => {
+
+  let min = Math.floor(Math.random() * 10);
+  let max = Math.floor(Math.random() * 100) + 11;
+  let maximum = new Maximum(max);
+
+  beforeEach(() => {
+    min = Math.floor(Math.random() * 10);
+    max = Math.floor(Math.random() * 100) + 11;
+    maximum = new Maximum(max);
+  });
+
+  testing
+    .toBeClass(Maximum)
+    .toBeNumberType(new Maximum(max).valueOf())
+    .toEqual(`Must be equal to ${max}`, new Maximum(max).valueOf(), max)
+
+    .it(`.create()`, () => {
+      const customMaximum = Maximum.create(max);
+      toBe
+        .instance(customMaximum, Maximum)
+        .numberBetween(customMaximum.valueOf(), min, max);
+    });
+});

--- a/src/test/minimum.spec.ts
+++ b/src/test/minimum.spec.ts
@@ -1,0 +1,33 @@
+// @angular-package/testing.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+// Class.
+import { Minimum } from '../lib/minimum.class';
+
+// Initialize.
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+
+testing.describe(`Minimum.`, () => {
+
+  let min = Math.floor(Math.random() * 10);
+  let max = Math.floor(Math.random() * 100) + 11;
+  let minimum = new Minimum(min);
+
+  beforeEach(() => {
+    min = Math.floor(Math.random() * 10);
+    max = Math.floor(Math.random() * 100) + 11;
+    minimum = new Minimum(min);
+  });
+
+  testing
+    .toBeClass(Minimum)
+    .toBeNumberType(new Minimum(min).valueOf())
+    .toEqual(`Must be equal to ${min}`, new Minimum(min).valueOf(), min)
+
+    .it(`.create()`, () => {
+      const customMinimum = Minimum.create(min);
+      toBe
+        .instance(customMinimum, Minimum)
+        .numberBetween(customMinimum.valueOf(), min, max);
+    });
+});

--- a/src/test/number.spec.ts
+++ b/src/test/number.spec.ts
@@ -1,0 +1,33 @@
+// @angular-package/testing.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+// Class.
+import { Number } from '../lib/number.class';
+
+// Initialize.
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+
+testing.describe(`Number.`, () => {
+
+  let min = Math.floor(Math.random() * 10);
+  let max = Math.floor(Math.random() * 100) + 11;
+  let minimum = new Number(min);
+
+  beforeEach(() => {
+    min = Math.floor(Math.random() * 10);
+    max = Math.floor(Math.random() * 100) + 11;
+    minimum = new Number(min);
+  });
+
+  testing
+    .toBeClass(Number)
+    .toBeNumberType(new Number(min).valueOf())
+    .toEqual(`Must be equal to ${min}`, new Number(min).valueOf(), min)
+
+    .it(`.create()`, () => {
+      const customNumber = Number.create(min);
+      toBe
+        .instance(customNumber, Number)
+        .numberBetween(customNumber.valueOf(), min, max);
+    });
+});

--- a/src/test/range.spec.ts
+++ b/src/test/range.spec.ts
@@ -1,0 +1,209 @@
+// @angular-package/testing.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+// Class.
+import { Range } from '../lib/range.class';
+// Initialize.
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+// Testing.
+testing.describe(`Range`, () => {
+
+  // Properties.
+  const min = -27;
+  const max = 27;
+  const step = 3;
+  const value = 25;
+
+  // Create new instance.
+  // Returns Range {min: 3, max: 27, value: 10} of Range<3, 27, 3>.
+  let range = new Range(min, max, value, step);
+
+  beforeEach(() => {
+    // Create new instance.
+    // Returns Range {min: 3, max: 27, value: 10} of Range<3, 27, 3>.
+    range = new Range(min, max, value, step);
+  });
+
+  testing
+    .describe(`Range.prototype.`, () => {
+      testing
+        .it(`max`, () => {
+          expect(range.max).toEqual(max);
+        })
+        .it(`min`, () => {
+          expect(range.min).toEqual(min);
+        })
+        .it(`step`, () => {
+          expect(range.step).toEqual(step);
+        })
+        .it(`value`, () => {
+          expect(range.value).toEqual(value);
+        })
+        .it(`steps`, () => {
+          const arr = [];
+          let current: number = range.min - range.step;
+          while (current < range.max) {
+            current <= value && current <= range.max && arr.push(current += range.step);
+          }
+          expect(range.steps).toEqual(arr.length);
+        });
+    })
+    .describe(`Range.prototype.`, () => {
+      testing
+        .it(`forEachStep()`, () => {
+          range.forEachStep((s, index, r) => {
+            expect(s).toEqual(range.range[index]);
+          });
+        })
+        .it(`getCurrentRange()`, () => {
+          toBe.array(range.getCurrentRange());
+          expect(range.getCurrentRange()?.length).toEqual(18);
+          expect(range.getCurrentRange()?.['17']).toEqual(24);
+        })
+        .it(`getCurrentStep()`, () => {
+          toBe
+            .number(range.getCurrentStep());
+          expect(range.getCurrentStep()).toEqual(Math.floor(value / step));
+        })
+        .it(`getRange()`, () => {
+          toBe.array(range.getRange());
+          // Picks entire range of 19 elements.
+          expect(range.getRange().length).toEqual(19);
+          // Picks only -27 in array.
+          expect(range.getRange(-27).length).toEqual(1);
+          // Picks 6 steps.
+          expect(range.getRange(range.min + (5 * step)).length).toEqual(6);
+          // Too small range. value.
+          expect(range.getRange(-28).length).toEqual(0);
+          // Too big range value.
+          expect(range.getRange(28).length).toEqual(19);
+        })
+        .it(`getRangeToStep()`, () => {
+          toBe.array(range.getRangeOfStep(6));
+          expect(range.getRangeOfStep(6)).toEqual(range.getRange(range.min + (5 * step)));
+          expect(range.getRangeOfStep(10)).toEqual(range.getRange(range.min + (9 * step)));
+        })
+        .it(`getValueOfStep()`, () => {
+          toBe.number(range.getValueOfStep(10));
+          expect(range.getValueOfStep(10)).toEqual(0);
+          expect(range.getValueOfStep(19)).toEqual(27);
+        })
+        .it(`has()`, () => {
+          toBe
+            .boolean(range.has(27))
+            .true(range.has(0))
+            .false(range.has(122.1));
+          expect(range.has(27)).toBeTrue();
+          expect(range.has(19)).toBeTrue();
+          expect(range.has(-27)).toBeTrue();
+          expect(range.has(-28)).toBeFalse();
+          expect(range.has(28)).toBeFalse();
+        })
+        .it(`hasEvery()`, () => {
+          toBe
+            .boolean(range.hasEvery(-27, 3, 23))
+            .true(range.hasEvery(0, -27, 27))
+            .false(range.hasEvery(122.1, 27, 3));
+          expect(range.hasEvery(27, 3, -27)).toBeTrue();
+          expect(range.hasEvery(-28, -27, 0)).toBeFalse();
+          expect(range.hasEvery(28, 0, 27)).toBeFalse();
+        })
+        .it(`hasSome()`, () => {
+          toBe
+            .boolean(range.hasSome(-27, 3, 23))
+            .true(range.hasSome(0, -28, 28))
+            .false(range.hasSome(122.1, 28, 222));
+          expect(range.hasSome(27, 3, -27)).toBeTrue();
+          expect(range.hasSome(-28, -28)).toBeFalse();
+        })
+        .it(`isBetween()`, () => {
+          toBe
+            .boolean(range.isBetween(-28, 28))
+            .true(range.isBetween(-27, 27))
+            .false(range.isBetween(-28, 28));
+          expect(range.isBetween(27, 27)).toBeTrue();
+          expect(range.isBetween(-28, 28)).toBeFalse();
+        })
+        .it(`isBetweenEvery()`, () => {
+          toBe
+            .boolean(range.isBetweenEvery([-28, 28], [1, 322]))
+            .true(range.isBetweenEvery([-27, 27], [27, 27] , [-27, -27]))
+            .false(range.isBetweenEvery([-28, 28], [1, 322]));
+          expect(range.isBetweenEvery([27, 27])).toBeTrue();
+          expect(range.isBetweenEvery([27, 27], [-28, 28])).toBeFalse();
+        })
+        .it(`isBetweenSome()`, () => {
+          toBe
+            .boolean(range.isBetweenSome([-28, 28], [1, 322]))
+            .true(range.isBetweenSome([-27, 27], [27, 27] , [-27, -27]))
+            .false(range.isBetweenSome([-28, 28], [1, 322]));
+          expect(range.isBetweenSome([27, 27], [-100, 100])).toBeTrue();
+          expect(range.isBetweenSome([27, 127], [-28, 28])).toBeFalse();
+        })
+        .it(`maxGreaterThan()`, () => {
+          toBe
+            .boolean(range.maxGreaterThan(27))
+            .true(range.maxGreaterThan(24))
+            .false(range.maxGreaterThan(28));
+          expect(range.maxGreaterThan(-27)).toBeTrue();
+          expect(range.maxGreaterThan(128)).toBeFalse();
+        })
+        .it(`maxLessThan()`, () => {
+          toBe
+            .boolean(range.maxLessThan(27))
+            .true(range.maxLessThan(28))
+            .false(range.maxLessThan(27));
+          expect(range.maxLessThan(127)).toBeTrue();
+          expect(range.maxLessThan(27)).toBeFalse();
+        })
+        .it(`minGreaterThan()`, () => {
+          toBe
+            .boolean(range.minGreaterThan(-27))
+            .true(range.minGreaterThan(-29))
+            .false(range.minGreaterThan(-27));
+          expect(range.minGreaterThan(-29)).toBeTrue();
+          expect(range.minGreaterThan(-27)).toBeFalse();
+        })
+        .it(`minLessThan()`, () => {
+          toBe
+            .boolean(range.minLessThan(-27))
+            .true(range.minLessThan(-26))
+            .false(range.minLessThan(-27));
+          expect(range.minLessThan(-26)).toBeTrue();
+          expect(range.minLessThan(-27)).toBeFalse();
+        })
+        .it(`setValue()`, () => {
+          expect(range.setValue(28).value).toEqual(25);
+          expect(range.setValue(-27).value).toEqual(-27);
+          expect(range.setValue(-28).value).toEqual(-27);
+          expect(range.setValue(0).value).toEqual(0);
+        })
+        .it(`setValueToStep()`, () => {
+          expect(range.setValueToStep(3).value).toEqual(range.getValueOfStep(3));
+          expect(range.setValueToStep(0).value).toEqual(-21);
+          expect(range.setValueToStep(5).value).toEqual(range.getValueOfStep(5));
+          expect(range.setValueToStep(20).value).toBeUndefined();
+        })
+        .it(`steByStep()`, () => {
+          range.stepByStep((v, s, m) => {
+            expect(s).toEqual(step);
+            expect(m).toEqual(max);
+            expect(v.next().value).toEqual(range.getValueOfStep(1));
+            expect(v.next().value).toEqual(range.getValueOfStep(2));
+            expect(v.next().value).toEqual(range.getValueOfStep(3));
+            expect(v.next().value).toEqual(range.getValueOfStep(4));
+            expect(v.next().value).toEqual(range.getValueOfStep(5));
+            expect(v.next().value).toEqual(range.getValueOfStep(6));
+          });
+        })
+        .it(`valueDown()`, () => {
+          expect(range.valueDown(5).value).toEqual(value - (5 * step));
+          expect(range.valueDown().value).toEqual(value - (6 * step));
+        })
+        .it(`valueUp()`, () => {
+          expect(range.valueUp().value).toEqual(25);
+          expect(range.valueDown(10).value).toEqual(value - (10 * step));
+          expect(range.valueUp(5).value).toEqual(-5 + (5 * step));
+        });
+    });
+});


### PR DESCRIPTION
## [1.0.0-rc] - 2022-02-26

### [1.0.0-rc] Added

- `Number` object. [32c36d4]
- `value` parameter of number type to the static `create()` method and `constructor()`. [622847e]
- private `#value` property that indicates the range current value of the number type. [622847e]
- `get` accessor `value` to retrieve the range value. [622847e]
- `set` accessor `value` to set the `#range` property including range of specified object. [622847e]
- `get` accessor `steps` to retrieve the number of steps. [622847e]
- the `getCurrentRange()` `getCurrentStep()` `getValueOfStep()` `setValue()` `setValueToStep()` `valueDown()` `valueUp()` methods. [622847e]

### [1.0.0-rc] Changed

- the static `isRange()` method by adding `step` parameter to check. [870c5e4]
- deprecate `getMin()` `getMax()` `valueOf()` `toArray()` methods. [622847e]
- `get` accessor `range`  to use `getRange()` method of instance and its return type to readonly. [622847e]
- the `getRange()` method to obtains the range to the specified value. [622847e]
- the `isBetween()` `isBetweenEvery()` `isBetweenSome()` methods to include minimum and maximum. [622847e]
- `forEachStep()` method parameter names and set `range` parameter type to readonly. [622847e]

[870c5e4]: https://github.com/angular-package/range/commit/870c5e4abb6addf140d6ae85ad7018b8ea117280
[32c36d4]: https://github.com/angular-package/range/commit/32c36d4ea5f3b7745571cb4034cd8e887aac2a00
[622847e]: https://github.com/angular-package/range/commit/622847e0d3042da88137e8a36c69fdeb3a8b7054